### PR TITLE
Correção cor icon Nativos (Busca) e loading Aur

### DIFF
--- a/big-store/usr/share/bigbashview/bcc/apps/big-store/css/appstream.css
+++ b/big-store/usr/share/bigbashview/bcc/apps/big-store/css/appstream.css
@@ -680,13 +680,19 @@ img.img_loading {
 
 .progress {
     position: relative;
+    height: 20px !important;
+    width: 40px !important;   
+    margin: -20px 0px 0px 9px;
+    /*
     height: 14px;
     width: 25px !important;
+    margin: -17px 0px 0px 16px;
+    */
     display: block;
     width: 84%;
     background-color: #acece6;
     border-radius: 2px;
-    margin: -17px 0px 0px 16px;
+    
     overflow: hidden;
 }
 

--- a/big-store/usr/share/bigbashview/bcc/apps/big-store/search_appstream_pamac.py
+++ b/big-store/usr/share/bigbashview/bcc/apps/big-store/search_appstream_pamac.py
@@ -94,8 +94,8 @@ if __name__ == "__main__":
                                 if num == 50:
                                     break
     if num > 0:
-        print ('<script>$(document).ready(function () {$("#box_appstream").show();});</script>')
-    print ('<script>document.getElementById("appstream_number").innerHTML = "', num, '"</script>')
+        print ('<script>runAvatarAppstream(); $(document).ready(function () {$("#box_appstream").show();});</script>')
+    print ('<script>document.getElementById("appstream_number").innerHTML = "', num, '";</script>')
 
     # Simple Search
     #for pkg in pkgs:


### PR DESCRIPTION
- Na busca por apps os ícones do Nativos quando aplicado Letras de cor não estava aplicando a cor ficando todos na cor cinza agora está corrigido
- E o loading por busca por pacotes Aur o check parecia um pacman do come-come he he, resolvi fazer um loading como se estivesse ligando várias vezes até carregar por completo. 